### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM docker.io/library/python:3.6-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE=reanahub/reana-auth-krb5
+IMAGE=docker.io/reanahub/reana-auth-krb5
 
 all:
 	@echo "Usage: make <action> where action is build, test, or push."
@@ -10,7 +10,7 @@ test:
 	docker run -i --rm $(IMAGE) klist 2>&1 | grep "klist: No credentials"
 
 lint:
-	docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+	docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 
 push:
 	docker push $(IMAGE)

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ true``, more information `here
 
 If you want to try it locally, a Kerberos token can be obtained via::
 
-   $ docker run -i -t --rm reanahub/reana-auth-krb5:1.0.1 /bin/bash
+   $ docker run -i -t --rm docker.io/reanahub/reana-auth-krb5:1.0.1 /bin/bash
    > kinit -k -t /path/to/keytab_file username@CERN.CH
    > klist
 


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.